### PR TITLE
CU_86byttmg9: integrate kafka package

### DIFF
--- a/.env.cluster
+++ b/.env.cluster
@@ -62,10 +62,10 @@ JS_REPORT_LICENSE_KEY=
 JS_REPORT_DEV_MOUNT=false
 JS_REPORT_PACKAGE_PATH=
 
-# Message Bus Kafka
-# Topics should comma seperated, optional include partion and repliction values
+# Message Bus - Kafka
+#  !NOTE: Topics should comma seperated, optional include partition and repliction values
 #   e.g. <topic>:<partions>:<replicationFactor> -> test:3:2 (defaults to <topics>:3:1)
-KAFKA_TOPICS=2xx,2xx-async,reprocess,3xx,metrics:3:3,patient,observation
+KAFKA_TOPICS=send-adt-to-pims,send-orm-to-pims,save-pims-patient,save-ipms-patient,handle-adt-from-ipms,handle-oru-from-ipms,reprocess,errors,metrics
 KAFKA_HOSTS=kafka-01:9092,kafka-02:9092,kafka-03:9092
 
 # Kafka consumer mapper

--- a/.env.local
+++ b/.env.local
@@ -14,3 +14,8 @@ OPENHIM_CONSOLE_IMAGE=jembi/openhim-console:latest
 OPENHIM_CORE_IMAGE=jembi/openhim-core:latest
 
 ES_BACKUPS_PATH=/tmp/backups
+
+# Message Bus - Kafka
+#  !NOTE: Topics should comma seperated, optional include partition and repliction values
+#   e.g. <topic>:<partions>:<replicationFactor> -> test:3:2 (defaults to <topics>:3:1)
+KAFKA_TOPICS=send-adt-to-pims,send-orm-to-pims,save-pims-patient,save-ipms-patient,handle-adt-from-ipms,handle-oru-from-ipms,reprocess,errors,metrics

--- a/.env.remote
+++ b/.env.remote
@@ -27,6 +27,7 @@ OPENHIM_MONGO_URL=mongodb://mongo-1:27017,mongo-2:27017,mongo-3:27017/openhim?re
 OPENHIM_MONGO_ATNAURL=mongodb://mongo-1:27017,mongo-2:27017,mongo-3:27017/openhim?replicaSet=mongo-set
 
 # Message Bus - Kafka
-# Topics should comma seperated, optional include partion and repliction values
+#  !NOTE: Topics should comma seperated, optional include partition and repliction values
 #   e.g. <topic>:<partions>:<replicationFactor> -> test:3:2 (defaults to <topics>:3:1)
-KAFKA_TOPICS=2xx,reprocess,3xx,metrics:3:1
+KAFKA_TOPICS=send-adt-to-pims,send-orm-to-pims,save-pims-patient,save-ipms-patient,handle-adt-from-ipms,handle-oru-from-ipms,reprocess,errors,metrics
+

--- a/README.md
+++ b/README.md
@@ -144,3 +144,19 @@ For dev environment you can access the Grafana UI and signin using the following
 - URL : http://localhost:3000
 - username : test
 - password : dev_password_only
+
+### Kafka (Kafdrop)
+
+For dev environment you can access the kafka (Kafdrop) UI viewer at the below endpoint:
+
+- URL : http://localhost:9013
+
+#### Kafka Pub/Sub testing
+
+For dev environment, you will need need to define an alias for the defined broker (kafka-01)
+
+Add the below alias to your `/etc/hosts`
+
+```
+0.0.0.0      kafka-01
+```

--- a/config.yaml
+++ b/config.yaml
@@ -11,6 +11,7 @@ packages:
   - identity-access-manager-keycloak
   - client-registry-opencr
   - analytics-datastore-elastic-search
+  - message-bus-kafka
 
 profiles:
   - name: dev
@@ -22,6 +23,7 @@ profiles:
       - identity-access-manager-keycloak
       - client-registry-opencr
       - analytics-datastore-elastic-search
+      - message-bus-kafka
     envFiles:
       - .env.local
     dev: true


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
-->

## Type of PR (check all applicable)

- [x] 💼 New Package
- [ ] ♻️ Refactor
- [ ] ✨ New Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🧪 Tests
- [ ] 🔖 Release
- [ ] 🚩 Other

## Description

Add the Kafka Message Bus package as part of the Platform deployment

Added the defined topics to be configured for kafka

CU_86byttmg9

## Tickets & Related Documents

Resolves CU_86byttmg9

## Screenshots/Recordings

![Screenshot from 2024-05-17 14-54-58](https://github.com/BWHIE/hie-botswana/assets/7311421/b9583259-841a-445e-9353-1577e7096ff4)

## Added code snippets?
- [ ] 👍 Yes
- [x] 🙅 No, because they aren't needed

## Added tests?

- [ ] 👍 Yes
- [x] 🙅 No, because they aren't needed
- [ ] 🙋 No, because I need help

### No tests? Add a note
<!-- 
If you didn't provide tests with this PR, please explain here why they aren't needed.
-->

## Added to documentation?

- [x] 📜 readme
- [ ] 📓 general documentation
- [ ] 🙅 no documentation needed

### No docs? Add a note
<!-- 
If you didn't provide documentation with this PR, please explain here why it's not needed.
-->

## Are there any post-deployment tasks we need to perform?

Kafka is configured to pub/sub within the docker network on Platform. Dev mode will expose the kafka port (9092) but this doesnt match the broker hostname defined (kafka-01)

If you want to test it out locally, a quick shortcut is to add an alias to your `/etc/hosts`
0.0.0.0 kafka-01