### PR TITLE
fix: mount dev volumes only when provided

### DIFF
--- a/packages/omang-service-mediator/docker-compose.dev.yml
+++ b/packages/omang-service-mediator/docker-compose.dev.yml
@@ -27,9 +27,6 @@ services:
       - target: 80
         published: 8098
         mode: host
-    volumes:
-      - ${OMANG_DEV_MOUNT_FOLDER}/src:/app/src
-      - ${OMANG_DEV_MOUNT_FOLDER}/node_modules:/app/node_modules
     command: ["npm", "run", "start:dev"]
 
 configs:

--- a/packages/omang-service-mediator/docker-compose.mnt.yml
+++ b/packages/omang-service-mediator/docker-compose.mnt.yml
@@ -1,0 +1,7 @@
+version: "3.8"
+
+services:
+  omang-api:
+    volumes:
+      - ${OMANG_DEV_MOUNT_FOLDER}/src:/app/src
+      - ${OMANG_DEV_MOUNT_FOLDER}/node_modules:/app/node_modules

--- a/packages/omang-service-mediator/swarm.sh
+++ b/packages/omang-service-mediator/swarm.sh
@@ -33,24 +33,24 @@ function import_sources() {
 
 function initialize_package() {
   local package_dev_compose_filename=""
+  local package_mnt_compose_filename=""
 
   if [ "${MODE}" == "dev" ]; then
     log info "Running package in DEV mode"
     package_dev_compose_filename="docker-compose.dev.yml"
-    if [[ -z "${OMANG_DEV_MOUNT_FOLDER}" ]]; then
-      log error "ERROR: OMANG_DEV_MOUNT_FOLDER environment variable not specified. Please specify OMANG_DEV_MOUNT_FOLDER as stated in the README."
-      exit 1
+    if [[ -n "${OMANG_DEV_MOUNT_FOLDER}" ]]; then
+      log info "Mounting dev volumes"
+      package_mnt_compose_filename="docker-compose.mnt.yml"
     fi
   else
     log info "Running package in PROD mode"
   fi
  
   (
-    docker::deploy_service "$STACK" "${COMPOSE_FILE_PATH}" "docker-compose.yml" "$package_dev_compose_filename"
+    docker::deploy_service "$STACK" "${COMPOSE_FILE_PATH}" "docker-compose.yml" "$package_dev_compose_filename" "$package_mnt_compose_filename"
   ) ||
     {
       log error "Failed to deploy package"
-      docker stack deploy --compose-file "${COMPOSE_FILE_PATH}/docker-compose.yml" --compose-file "${COMPOSE_FILE_PATH}/docker-compose.dev.yml" omang-service-mediator
       exit 1
     }
 }

--- a/packages/shared-health-record/docker-compose.dev.yml
+++ b/packages/shared-health-record/docker-compose.dev.yml
@@ -1,8 +1,6 @@
 services:
   shared-health-record:
     entrypoint: node --inspect=0.0.0.0:9230 /app/dist/app.js
-    volumes:
-      - ${SHR_DEV_MOUNT_FOLDER}:/app/dist
     ports:
       - target: 9230
         published: 9230

--- a/packages/shared-health-record/docker-compose.mnt.yml
+++ b/packages/shared-health-record/docker-compose.mnt.yml
@@ -1,0 +1,4 @@
+services:
+  shared-health-record:
+    volumes:
+      - ${SHR_DEV_MOUNT_FOLDER}:/app/dist

--- a/packages/shared-health-record/swarm.sh
+++ b/packages/shared-health-record/swarm.sh
@@ -39,9 +39,15 @@ function import_sources() {
 
 function initialize_package() {
   local package_dev_compose_filename=""
+  local package_mnt_compose_filename=""
+
   if [[ "${MODE}" == "dev" ]]; then
     log info "Running package in DEV mode"
     package_dev_compose_filename="docker-compose.dev.yml"
+    if [[ -n "${SHR_DEV_MOUNT_FOLDER}" ]]; then
+      log info "Mounting dev volumes"
+      package_mnt_compose_filename="docker-compose.mnt.yml"
+    fi
   else
     log info "Running package in PROD mode"
   fi
@@ -49,7 +55,7 @@ function initialize_package() {
   log info "Deploying package with compose file: ${COMPOSE_FILE_PATH}/docker-compose.yml ${package_dev_compose_filename}"
   
   (
-    docker::deploy_service $STACK "${COMPOSE_FILE_PATH}" "docker-compose.yml" "$package_dev_compose_filename"
+    docker::deploy_service $STACK "${COMPOSE_FILE_PATH}" "docker-compose.yml" "$package_dev_compose_filename" "$package_mnt_compose_filename"
   ) || {
     log error "Failed to deploy package"
     exit 1


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
-->

## Type of PR (check all applicable)

- [ ] 💼 New Package
- [x] ♻️ Refactor
- [ ] ✨ New Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🧪 Tests
- [ ] 🔖 Release
- [ ] 🚩 Other

## Description

<!-- Please do not leave this blank -->

This PR allows to mount dev volumes only when path is provided.
